### PR TITLE
Add selected = true in airbyte_connection resource example

### DIFF
--- a/examples/resources/airbyte_connection/resource.tf
+++ b/examples/resources/airbyte_connection/resource.tf
@@ -92,6 +92,7 @@ resource "airbyte_connection" "e2e" {
     destination_config = merge(
       data.airbyte_source_schema_catalog.custom.sync_catalog.0.destination_config,
       {
+        selected              = true
         alias_name            = "data_stream_destination_alias"
         destination_sync_mode = "overwrite"
         sync_mode             = "full_refresh"


### PR DESCRIPTION
The `airbyte_connection` resource example does not work as of Airbyte 0.50.x (maybe anterior versions as well). This PR updates the example to make it functional again.

-----------------------------------

It looks like the `selected` flag is set to `false` by default in the `sync_catalog.[].destination_config`. 
When none of the streams has `selected = true`, the calls to `/api/v1/connections/create` and `/api/v1/connections/update` will fail with a 500.

Terraform logs:
![image](https://github.com/josephjohncox/terraform-provider-airbyte/assets/26208387/8dde042e-fd4f-45da-99af-7e09d885bb8e)

airbyte-server logs:
<img width="1421" alt="image" src="https://github.com/josephjohncox/terraform-provider-airbyte/assets/26208387/ac7c019c-3d86-44b8-aee6-3492532da1ca">
